### PR TITLE
fix: ambiguous I2C address type in Wire.requestFrom() call

### DIFF
--- a/src/TE_SM9000.cpp
+++ b/src/TE_SM9000.cpp
@@ -26,7 +26,7 @@ void SM9000_sensor::readData()
   Wire.beginTransmission(I2C_address);
   Wire.write(0x2E);
   Wire.endTransmission(false);
-  Wire.requestFrom(I2C_address, 6, true);
+  Wire.requestFrom((uint8_t)I2C_address, (size_t)6, true);
   for(int i = 0; i < 6; i++)
   {
   	if(Wire.available()) {


### PR DESCRIPTION
modified I2C address cast to uint8_t and size parameter cast to size_t to resolve compiler warnings about ambiguous function overloads.
this change ensures that the correct Wire.requestFrom() function is called, and fixes warnings that were previously generated